### PR TITLE
Add 'Accept: application/json' header

### DIFF
--- a/PestJSON.php
+++ b/PestJSON.php
@@ -34,6 +34,7 @@ class PestJSON extends Pest
   }
 
   protected function prepRequest($opts, $url) {
+    $opts[CURLOPT_HTTPHEADER][] = 'Accept: application/json';
     $opts[CURLOPT_HTTPHEADER][] = 'Content-Type: application/json';
     return parent::prepRequest($opts, $url);
   }


### PR DESCRIPTION
To support services that use content negotiation (via the Accept header) to determine what format to respond with.

p.s. pest is handy, found it via stackoverflow - nice work! :-)
