### PR TITLE
Added option to get params as array

### DIFF
--- a/Pest.php
+++ b/Pest.php
@@ -37,7 +37,10 @@ class Pest {
     $this->curl_opts[CURLOPT_USERPWD] = $user . ":" . $pass;
   }
   
-  public function get($url) {
+  public function get($url, $params=array()) {
+    $params = (is_array($params)) ? http_build_query($params) : $params;
+    $url = $url.'?'.$params;
+
     $curl = $this->prepRequest($this->curl_opts, $url);
     $body = $this->doRequest($curl);
     


### PR DESCRIPTION
I was pretty confused when I used

```
Pest->get('url', array(....));
```

And I think this will help others too, will make all HTTP calls standard, and user would have ease of use when he can just pass an array into get calls.

Thanks,
Munir
