### PR TITLE
fix for empty xml docs like http://pastebin.com/gdT2V37y

### DIFF
--- a/PestXML.php
+++ b/PestXML.php
@@ -29,11 +29,15 @@ class PestXML extends Pest {
     
     if (!$xml) {
       $err = "Couldn't parse XML response because:\n";
-      foreach(libxml_get_errors() as $xml_err)
-        $err .= "\n    - " . $xml_err->message;
-      $err .= "\nThe response was:\n";
-      $err .= $body;
-      throw new PestXML_Exception($err);
+      $xml_errors = libxml_get_errors();
+      if(!empty($xml_errors))
+      {
+        foreach(libxml_get_errors() as $xml_err)
+          $err .= "\n    - " . $xml_err->message;
+        $err .= "\nThe response was:\n";
+        $err .= $body;
+        throw new PestXML_Exception($err);
+      }
     }
     
     return $xml;


### PR DESCRIPTION
This makes sure that libxml_get_errors() actually returns something before sending out an error. Also this is my first pull request so go easy and help me out :D
