### PR TITLE
Added an addHeader() method

### DIFF
--- a/Pest.php
+++ b/Pest.php
@@ -44,9 +44,9 @@ class Pest {
   // Lets you add a header to the header list
   // Example: pest->addHeader("Accept", "application/xml");
   public function addHeader($headerName, $value) {
-      if (is_array($this->curl_opts[CURLOPT_HTTPHEADER])) {
+      try {
           array_push($this->curl_opts[CURLOPT_HTTPHEADER], $headerName.":".$value);
-      } else {
+      } catch (Exception $e) {
           $this->curl_opts[CURLOPT_HTTPHEADER] = array($headerName.":".$value);
       }
   }


### PR DESCRIPTION
-Added an addHeader() method that lets you add a header value to the Pest object before doing a get() for example.

I was trying to make a call to a third party API and I could get curl to work in a shell_exec(), I tried with both Pest() and PestXML() but each time I would get a HTTP: Basic Authorization Denied. In my curl line I was using -h 'Accept: application/xml', so I added the addHeader() method and added it to the curl_opts array and I got it to work.

ex:
require "libs/pest/Pest.php";

$pest = new Pest('http://www.somesite.com');

$pest->addHeader("Accept", "application/xml");
$pest->setupAuth("a_user_name", "a_password");

echo $pest->get('/api/path');
