### PR TITLE
Add is_string check before doning string comparing

### DIFF
--- a/Pest.php
+++ b/Pest.php
@@ -71,7 +71,7 @@ class Pest {
         $multipart = false;
         
         foreach ($data as $item) {
-            if (strncmp($item, "@", 1) == 0 && is_file(substr($item, 1))) {
+            if (is_string($item) && strncmp($item, "@", 1) == 0 && is_file(substr($item, 1))) {
                 $multipart = true;
                 break;
             }


### PR DESCRIPTION
...nction

Because sometime JSON data may be a multi dimension array as following:
array(
  "a": []
) 
In this case, this express will cause 2 PHP warning.
