### PR TITLE
add $data parameter to get function

### DIFF
--- a/Pest.php
+++ b/Pest.php
@@ -57,7 +57,15 @@ class Pest {
     }
   }
   
-  public function get($url) {
+  public function get($url, $data=array()) {
+    if (!empty($data)) {
+        $pos = strpos($url, '?');
+        if ($pos !== false) {
+            $url = substr($url, 0, $pos);
+        }
+        $url .= '?' . http_build_query($data);
+    }
+
     $curl = $this->prepRequest($this->curl_opts, $url);
     $body = $this->doRequest($curl);
     


### PR DESCRIPTION
Adds get params as `$data` array to the get function, like this:
`Pest->get('url', array('id' => 1));`

This is the same idea as with https://github.com/educoder/pest/pull/11 but with a few fixes: If the `$data` array is set and the `$url` already contains parameters, the `$url` parameters are replaced.
