### PR TITLE
Fix for missing CURLOPT_HTTPHEADER initialization

### DIFF
--- a/Pest.php
+++ b/Pest.php
@@ -13,7 +13,8 @@ class Pest {
   	CURLOPT_RETURNTRANSFER => true,  // return result instead of echoing
   	CURLOPT_SSL_VERIFYPEER => false, // stop cURL from verifying the peer's certificate
   	CURLOPT_FOLLOWLOCATION => false,  // follow redirects, Location: headers
-  	CURLOPT_MAXREDIRS      => 10     // but dont redirect more than 10 times
+  	CURLOPT_MAXREDIRS      => 10,     // but dont redirect more than 10 times
+    CURLOPT_HTTPHEADER     => array()
   );
 
   public $base_url;


### PR DESCRIPTION
When sending POST after last fix that changed: 
$curl_opts[CURLOPT_HTTPHEADER] = $headers;
to:
$curl_opts[CURLOPT_HTTPHEADER] = array_merge($headers,$curl_opts[CURLOPT_HTTPHEADER]);
it ends with:
"Notice: Undefined offset: 10023 in (here path)/vendor/lib/Pest.php line 112"
because CURLOPT_HTTPHEADER is not initialized with empty array.
