### PR TITLE
Allow custom HTTP headers to be sent via GET / command

### DIFF
--- a/Pest.php
+++ b/Pest.php
@@ -175,9 +175,10 @@ class Pest {
     return $body;
   }
   
-  public function delete($url) {
+  public function delete($url, $headers = array()) {
     $curl_opts = $this->curl_opts;
     $curl_opts[CURLOPT_CUSTOMREQUEST] = 'DELETE';
+    $curl_opts[CURLOPT_HTTPHEADER] = $this->getHeaders($headers);
     
     $curl = $this->prepRequest($curl_opts, $url);
     $body = $this->doRequest($curl);


### PR DESCRIPTION
Right now, there's no possibility to alter request headers should we need to. This pull request fixes it.
