### PR TITLE
Allow associative header arrays for all methods

### DIFF
--- a/Pest.php
+++ b/Pest.php
@@ -169,6 +169,17 @@ class Pest
     }
     
     /**
+     * Determines if a given array is numerically indexed or not
+     *
+     * @param array $array
+     * @return boolean
+     */
+    protected function _isNumericallyIndexedArray($array)
+    {
+        return !(bool)count(array_filter(array_keys($array), 'is_string'));
+    }
+    
+    /**
      * Flatten headers from an associative array to a numerically indexed array of "Name: Value"
      * style entries like CURLOPT_HTTPHEADER expects. Numerically indexed arrays are not modified.
      *
@@ -177,8 +188,7 @@ class Pest
      */
     protected function prepHeaders($headers)
     {
-        // Skip if the array is already numerically indexed
-        if (!(bool)count(array_filter(array_keys($headers), 'is_string'))) {
+        if ($this->_isNumericallyIndexedArray($headers)) {
             return $headers;
         }
         


### PR DESCRIPTION
This pull request allows users to specify an associative array of headers for any HTTP method (in addition to the existing numerically indexed format).  For example, given two arrays, one numerically indexed and the other associative, the following Pest calls will now perform the same HTTP GET:

``` php
$headers_numeric = array(
    'X-Random-Header: ExampleValue',
    'X-Awesome-Header: AwesomeValue'
);
$headers_assoc = array(
    'X-Random-Header' => 'ExampleValue',
    'X-Awesome-Header' => 'AwesomeValue'
);

$pest = new Pest('http://educoder.github.io');
$pest->get('/blog/', false, $headers_numeric);
$pest->get('/blog/', false, $headers_assoc);
```

Prior to this pull request, the latter `get()` would be performed, but the headers would be silently discarded. It took me a little while to figure out why, and I thought I'd write this improvement so that either header array format will work as the user expects.
