### PR TITLE
Allow http_build_query() override

### DIFF
--- a/Pest.php
+++ b/Pest.php
@@ -127,6 +127,15 @@ class Pest
             $this->curl_opts[CURLOPT_PROXYUSERPWD] = $user . ":" . $pass;
         }
     }
+    
+    /**
+	 * Allow overriding of `http_build_query()` for idiosyncratic APIs
+	 * @param mixed $data
+	 * @return string
+	 **/
+    protected function http_build_query($data) {
+	    return http_build_query($data);
+    }
 
     /**
      * Perform HTTP GET request
@@ -143,7 +152,7 @@ class Pest
             if ($pos !== false) {
                 $url = substr($url, 0, $pos);
             }
-            $url .= '?' . http_build_query($data);
+            $url .= '?' . $this->http_build_query($data);
         }
 
         $curl_opts = $this->curl_opts;
@@ -410,7 +419,7 @@ class Pest
                 }
             }
 
-            return ($multipart) ? $data : http_build_query($data);
+            return ($multipart) ? $data : $this->http_build_query($data);
         } else {
             return $data;
         }
@@ -452,7 +461,7 @@ class Pest
      */
     public function patch($url, $data, $headers = array())
     {
-        $data = (is_array($data)) ? http_build_query($data) : $data;
+        $data = (is_array($data)) ? $this->http_build_query($data) : $data;
 
         $curl_opts = $this->curl_opts;
         $curl_opts[CURLOPT_CUSTOMREQUEST] = 'PATCH';


### PR DESCRIPTION
This seems like the kind of thing that one should never want to do. Unless... you're dealing with a RESTful API that doesn't seem to understand URL parameters that contain numeric indices for the base array. [For example](https://github.com/smtech/canvaspest/issues/3):

Instructure Canvas is expecting URL parameters for arrays that do not include numerical indices:

```
http://canvas-instance.instructure.com/api/v1/courses/123/sections?include[]=students&include[]=enrollments
```

At the same time [`http_build_query()`](https://github.com/smtech/canvaspest/blob/9110d69f756ff49e8da687381eaee52a767c0389/CanvasPest.php#L108) is trying to build legal URL parameters, which require that at least the base URL be indexed, resulting in shenanigans like this:

```
http://canvas-instance.instructure.com/api/v1/courses/123/sections?include%5B0%5D=students&include%5B1%5D=enrollments
```

Adding in an override-able `Pest::http_build_query()` method allows for child classes to make necessary tweaks to the URL parameters before sending them to the API. For example:

```PHP
class CanvasPest extends Pest {

  /* ... */

  protected function http_build_query($data) {
    return preg_replace('/%5b\d+%5B/simU', '[]', http_build_query($data));
  }

  /* ... */

}
```