### PR TITLE
Fix for issue #71 (Content-Length injection into header fields)

### DIFF
--- a/Pest.php
+++ b/Pest.php
@@ -202,7 +202,7 @@ class Pest
      */
     protected function _isNumericallyIndexedArray($array)
     {
-        return !(bool)count(array_filter(array_keys($array), 'is_string'));
+        return !(bool)(count(array_filter(array_keys($array), 'is_string')) === 0);
     }
     
     /**


### PR DESCRIPTION
Fixed the issues I reported previously in ticket #71 .

The prepHeaders() method now
* checks if 'Content-Length' parameter needs to be added (when you pass the second param)
* checks if the parameter exists
* inserts 'Content-Length' parameter regarding the structure of the array (numerically indexed or associative)

Also fixed _isNumericallyIndexedArray() so it will return FALSE when the supplied array's indexes are mixed.